### PR TITLE
Fix CI build failure by removing exit 1 command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,3 @@ jobs:
     steps:
       # - uses: actions/checkout@v5
       - run: echo "Hello, world!"
-      - run: exit 1


### PR DESCRIPTION
## Summary
This PR fixes the CI build failure identified in workflow run [#18366655784](https://github.com/austenstone/copilot-cli-actions/actions/runs/18366655784).

## Changes
- Removed the intentional `exit 1` command from the CI workflow that was causing the build to fail
- The CI workflow will now complete successfully after echoing "Hello, world!"

## Details
The build job was failing with exit code 1 due to the `- run: exit 1` step in `.github/workflows/ci.yml`. This step has been removed to allow the workflow to pass.

**Analysis:**
- **Repository:** austenstone/copilot-cli-actions
- **Branch:** main
- **Commit:** 4631fb604ef655eceaa1434739f07ec3d78ac9a8
- **Failed workflow:** https://github.com/austenstone/copilot-cli-actions/actions/runs/18366653506
- **Error:** Process completed with exit code 1

Fixes the failure in commit 4631fb604ef655eceaa1434739f07ec3d78ac9a8.