### PR TITLE
Fix CI workflow by removing intentional failure step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,3 @@ jobs:
     steps:
       # - uses: actions/checkout@v5
       - run: echo "Hello, world!"
-      - run: exit 1


### PR DESCRIPTION
This PR fixes the CI workflow failure by removing the `exit 1` command that was causing the build to fail.

## Changes
- Removed the `exit 1` step from the CI workflow

## Related
- Fixes workflow run: https://github.com/austenstone/copilot-cli-actions/actions/runs/18366726549

The workflow was failing at step 3 with an intentional `exit 1` command. This change removes that failing step to allow the CI workflow to complete successfully.