### PR TITLE
Fix CI workflow: Remove intentional exit 1 failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
       - run: echo "Hello, world!"
-      - run: exit 1
+      - run: echo "CI workflow completed successfully"


### PR DESCRIPTION
## Problem
The CI workflow (run [#18366865616](https://github.com/austenstone/copilot-cli-actions/actions/runs/18366865616)) was failing due to an intentional `exit 1` command in the workflow definition.

## Error Details
From the failed workflow run:
- **Job**: build
- **Failed Step**: Run exit 1
- **Error**: Process completed with exit code 1
- **Commit**: ad899c8bf1d81d7c795d83d7707a0781a344c281

## Changes
This PR fixes the CI workflow by:
- ✅ Removing the `exit 1` step that was causing the workflow to fail
- ✅ Uncommenting the `actions/checkout@v5` action for proper repository access
- ✅ Adding a success message step to confirm workflow completion

## Workflow Logs
```
buildRun exit 1﻿2025-10-09T05:50:53.5914630Z ##[group]Run exit 1
buildRun exit 12025-10-09T05:50:53.5915177Z exit 1
buildRun exit 12025-10-09T05:50:53.5945245Z shell: /usr/bin/bash -e {0}
buildRun exit 12025-10-09T05:50:53.5945813Z ##[endgroup]
buildRun exit 12025-10-09T05:50:53.6009765Z ##[error]Process completed with exit code 1.
```

## Testing
After merging, the CI workflow should run successfully without failures.