### PR TITLE
Fix CI workflow failure - Remove intentional exit 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
       - run: echo "Hello, world!"
-      - run: exit 1
+      - run: echo "CI workflow completed successfully"


### PR DESCRIPTION
## Issue
Workflow run [#18](https://github.com/austenstone/copilot-cli-actions/actions/runs/18367447372) failed due to an intentional `exit 1` command in the CI workflow.

## Error Details
- **Workflow**: CI (.github/workflows/ci.yml)
- **Failed Step**: `Run exit 1` (step 3)
- **Job**: build
- **Conclusion**: failure

### Error Log
```
Step 3: Run exit 1
Status: completed
Conclusion: failure
```

## Changes Made
1. **Removed** the `exit 1` command that was causing the workflow to fail
2. **Replaced** with `echo "CI workflow completed successfully"` for proper completion
3. **Uncommented** the `actions/checkout@v5` step for proper repository setup

## Testing
Once merged, this will allow the CI workflow to complete successfully with all steps passing.

## Related
- Fixes workflow run: https://github.com/austenstone/copilot-cli-actions/actions/runs/18367447372