### PR TITLE
Fix CI workflow: Remove deliberate failure step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
       - run: echo "Hello, world!"
-      - run: exit 1
+      - run: echo "CI workflow completed successfully"


### PR DESCRIPTION
## Summary
This PR fixes the failing CI workflow by removing the deliberate `exit 1` command that was causing builds to fail.

## Problem Analysis
The CI workflow (run #18368442050) was failing consistently due to a hardcoded failure step:

**Failed Workflow Details:**
- **Workflow Run ID:** 18368442050
- **Job ID:** 52325872640
- **Failed Step:** 'Run exit 1' (step 3)
- **Conclusion:** failure
- **Error:** Command `exit 1` returns non-zero exit code

## Root Cause
Line 16 in `.github/workflows/ci.yml` contained `exit 1` which deliberately fails the build every time.

## Changes Made
1. ✅ Removed the `exit 1` step that was causing the build to fail
2. ✅ Replaced it with a success message: `echo "CI workflow completed successfully"`
3. ✅ Uncommented the `actions/checkout@v5` action to ensure proper repository access

## Testing
The workflow should now complete successfully with all steps passing.

## Related
- Fixes workflow run: https://github.com/austenstone/copilot-cli-actions/actions/runs/18368442050