### PR TITLE
Fix: Remove intentional CI workflow failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # - uses: actions/checkout@v5
+      - uses: actions/checkout@v5
       - run: echo "Hello, world!"
-      - run: exit 1
+      - run: echo "CI workflow completed successfully"


### PR DESCRIPTION
## Summary
This PR fixes the CI workflow failure identified in workflow run #18382306889.

## Problem
The CI workflow was failing due to an intentional `exit 1` command in step 3 of the build job.

## Error Details
From the failed workflow run:
- **Workflow**: CI
- **Run ID**: 18382306889
- **Conclusion**: failure
- **Failed Step**: Step 3 - 'Run exit 1' (exit code 1)

## Changes Made
1. **Removed the `exit 1` command** that was causing the build to fail
2. **Uncommented the checkout action** (`actions/checkout@v5`) to properly set up the workspace
3. **Added a success message** to confirm workflow completion

## Testing
The workflow should now complete successfully with all steps passing:
- ✅ Checkout repository
- ✅ Echo "CI workflow completed successfully"

## Related
- Fixes workflow run: https://github.com/austenstone/copilot-cli-actions/actions/runs/18382306889
- Triggered by commit: a7159e19e6dfb511b5dd908e190f202ee759d27b