### PR TITLE
Fix CI workflow failure - Remove exit 1 command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,4 +13,3 @@ jobs:
     steps:
       # - uses: actions/checkout@v5
       - run: echo "Hello, world!"
-      - run: exit 1


### PR DESCRIPTION
## Problem
The CI workflow is failing due to an intentional `exit 1` command in step 3.

## Error Analysis
**Workflow Run:** https://github.com/austenstone/copilot-cli-actions/actions/runs/18384329923

**Failed Step:** Run exit 1
- **Conclusion:** failure
- **Exit Code:** 1

## Root Cause
The CI workflow (.github/workflows/ci.yml) contains a deliberate failure command:
```yaml
- run: exit 1
```

## Solution
Removed the `exit 1` command that was causing the workflow to fail. The workflow now:
2. Completes successfully

## Changes Made
- Removed line 16: `- run: exit 1` from .github/workflows/ci.yml

## Testing
The CI workflow should now pass successfully on this branch.