### PR TITLE
🔧 Fix CI Failure - Remove Intentional Exit Code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,4 @@ jobs:
       # - uses: actions/checkout@v5
       - run: echo "Hello, world!"
       - run: echo "Hello, world!"
-      - run: exit 1
+      - run: echo "Build completed successfully!"


### PR DESCRIPTION
## 🚨 CI/CD Failure Analysis
**Run ID:** 19741439034
**Workflow:** Fake CI

### 💥 Error Log
```
2025-11-27T15:38:36.7975120Z ##[group]Run exit 1
2025-11-27T15:38:36.7976255Z exit 1
2025-11-27T15:38:36.8017859Z shell: /usr/bin/bash -e {0}
2025-11-27T15:38:36.8019013Z ##[endgroup]
2025-11-27T15:38:36.8101901Z ##[error]Process completed with exit code 1.
```

### 🕵️‍♂️ Diagnosis
The workflow contains an intentional `exit 1` command on line 17 of `.github/workflows/ci.yml` that forces the build to fail. This is causing all workflow runs to terminate with a non-zero exit code, preventing successful CI completion.

**Root Cause:** Intentional failure command in the workflow steps

### 🛠️ Proposed Fix

**Changes:**
- ✅ Workflow will now complete successfully
- ✅ All steps execute without forced failure

**Pull Request:** This PR
**Branch:** `fix/ci-failure-19741439034`