### PR TITLE
Copilot Fix(CI Failure): Remove intentional exit 1 failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,4 @@ jobs:
       # - uses: actions/checkout@v5
       - run: echo "Hello, world!"
       - run: echo "Hello, world!"
-      - run: exit 1
+      - run: echo "CI test passed successfully!"


### PR DESCRIPTION
## Summary
The 'Fake CI' workflow was failing due to an intentional `exit 1` command on line 17 of the workflow file.

Why did the build cross the road? To get to the other `exit 0`! 🚀

**Failed Run:** https://github.com/austenstone/copilot-cli/actions/runs/19741691953

### 💥 Error Log
```
2025-11-27T15:48:32.6631190Z ##[group]Run exit 1
2025-11-27T15:48:32.6632370Z exit 1
2025-11-27T15:48:32.6674889Z shell: /usr/bin/bash -e {0}
2025-11-27T15:48:32.6675806Z ##[endgroup]
2025-11-27T15:48:32.6755983Z ##[error]Process completed with exit code 1.
```

### 🕵️‍♂️ Diagnosis
The workflow contained a deliberate `exit 1` command that caused the job to fail unconditionally. This is the final step in the workflow after two echo commands, ensuring that every run of this workflow fails regardless of the previous steps' success.

**Root Cause:** Line 17 in `.github/workflows/ci.yml` contains `- run: exit 1` which always returns a failure exit code.

**Category:** Syntax/Logic Error

### 🛠️ Proposed Fix
Replace the failing `exit 1` command with a successful completion message:
- **Before:** `- run: exit 1`

This change ensures the workflow completes successfully while maintaining the existing test structure.