### PR TITLE
🤖 fix: restore setup-node + npm install (actions/setup-copilot@v0 404s)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -138,16 +138,23 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-copilot@v0
+    - uses: actions/setup-node@v6
       with:
-        version: ${{ inputs.copilot-version }}
+        node-version: '22'
     - name: Run GitHub Copilot CLI
       id: copilot
       shell: bash
       run: |
         # Script
 
-        echo "::group::Copilot CLI Version"
+        echo "::group::Install GitHub Copilot CLI"
+        if [ "$COPILOT_VERSION" = "latest" ]; then
+          npm install -g @github/copilot
+        elif [ "$COPILOT_VERSION" = "prerelease" ]; then
+          npm install -g @github/copilot@prerelease
+        else
+          npm install -g @github/copilot@$COPILOT_VERSION
+        fi
         echo "CLI Version: $(copilot --version)"
         echo "::endgroup::"
 
@@ -317,6 +324,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.copilot-token }}
         GH_TOKEN: ${{ inputs.repo-token }}
         PROMPT: ${{ inputs.prompt }}
+        COPILOT_VERSION: ${{ inputs.copilot-version }}
         CONFIG: ${{ inputs.copilot-config }}
         MCP_CONFIG: ${{ inputs.mcp-config }}
         ALLOW_ALL_TOOLS: ${{ inputs.allow-all-tools }}


### PR DESCRIPTION
> 🤖 AI-generated, review before merging. Heartbeat agent noticed the monthly `copilot-actions-report.yml` workflow failed on both 2026-05-01 and 2026-06-01 with the same root cause. Confidence high on diagnosis (404 reproducible), medium on fix (restores known-prior-working pattern, but if `actions/setup-copilot` is supposed to be a private/internal action we should publish that instead).

## Problem

The composite action references `actions/setup-copilot@v0` (introduced in [`8f923b7`](https://github.com/austenstone/copilot-cli/commit/8f923b7) on 2026-03-11):

```yaml
- uses: actions/setup-copilot@v0
  with:
    version: ${{ inputs.copilot-version }}
```

That repository **does not exist publicly** (`gh api repos/actions/setup-copilot` → 404). As a result, every consumer of `austenstone/copilot-cli@main` is broken right now.

Evidence: 2 consecutive monthly runs failed on this repo's own [`copilot-actions-report.yml`](https://github.com/austenstone/copilot-cli/actions/workflows/copilot-actions-report.yml) — `2026-05-01` and `2026-06-01` — both with `##[error]Unable to resolve action 'actions/setup-copilot', not found`. The `2026-04-01` run succeeded, which suggests the action was reachable then and has since been removed or made private.

## Fix

Restore the pre-3/11 install pattern: `actions/setup-node@v6` + `npm install -g @github/copilot`. Version handling is restored as it was, plus an explicit `prerelease` branch to match the current default of `inputs.copilot-version`. `COPILOT_VERSION` is re-added to the `env` block.

## Decision needed

1. **Merge** if there's no near-term plan to publish `actions/setup-copilot` publicly. Drop-in revert of one step, no other behavior changes.
2. **Close** if `actions/setup-copilot` is meant to exist (e.g. private to a github-org and slipping out via this action) — in which case the right fix is publish/transfer.

Either way the current state is broken for all `@main` consumers.
