### PR TITLE
fix: scope agent to workspace by default instead of root (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Use `secret-env-vars` to strip and redact sensitive values from shell/MCP enviro
 | `allowed-urls` | Comma-separated list of URLs/domains to allow | ❌ | - |
 | `denied-urls` | Comma-separated list of URLs/domains to deny | ❌ | - |
 | `allow-all-urls` | Allow access to all URLs without confirmation | ❌ | `false` |
-| `allow-all-paths` | Disable file-path verification and allow access to any path | ❌ | `false` |
+| `allow-all-paths` | Allow access to any file path without approval. When `false` (default), the agent is scoped to the workspace instead of the entire filesystem | ❌ | `false` |
 | `secret-env-vars` | Comma-separated env var names whose values are stripped from shell/MCP environments and redacted from output/logs (e.g., `"API_KEY,DB_PASSWORD"`) | ❌ | - |
 | **MCP Configuration** | | | |
 | `enable-all-github-mcp-tools` | Enable all GitHub MCP tools | ❌ | `false` |

--- a/action.yml
+++ b/action.yml
@@ -133,7 +133,7 @@ inputs:
     required: false
     default: false
   allow-all-paths:
-    description: 'Allow access to all file paths without approval'
+    description: 'Allow access to all file paths without approval. When false (default), the agent is scoped to $GITHUB_WORKSPACE instead of the entire filesystem.'
     required: false
     default: false
   context:
@@ -230,7 +230,13 @@ runs:
         echo "::group::Copilot Options"
         COPILOT_ARGS=""
 
-        COPILOT_ARGS+="--add-dir / "
+        # Default to the checked-out workspace instead of the whole filesystem.
+        # Root access is opt-in via allow-all-paths to limit untrusted-prompt blast radius (#70).
+        if [ "$ALLOW_ALL_PATHS" = "true" ]; then
+          COPILOT_ARGS+="--add-dir / "
+        else
+          COPILOT_ARGS+="--add-dir $GITHUB_WORKSPACE "
+        fi
         if [ -n "$ADDITIONAL_DIRS" ]; then
           IFS=',' read -ra DIRS <<< "$ADDITIONAL_DIRS"
           for dir in "${DIRS[@]}"; do


### PR DESCRIPTION
## What

Stops hardcoding `--add-dir /` on every run. The Copilot agent now defaults to `--add-dir $GITHUB_WORKSPACE` (the checked-out repo), and root filesystem access is gated behind the existing `allow-all-paths` opt-in.

## Why

`action.yml` granted the agent read access to the **entire filesystem** on every invocation, regardless of inputs. When a workflow interpolates untrusted issue/PR/comment content into the `prompt`, that over-broad surface widens the blast radius — the actionable core of the Agentic Workflow Injection report in #70.

## Backward compatibility

Fully preserved via escape hatch: set `allow-all-paths: true` to restore the old `--add-dir /` behavior. Most consumers only touch the workspace repo, so they're unaffected.

## Validation

- ✅ YAML valid
- ✅ `ALLOW_ALL_PATHS` already mapped in the same step's env block
- ✅ zizmor: no new findings (only pre-existing ad-hoc `npm install` notes)
- ✅ README `allow-all-paths` row updated to reflect the safe default

Addresses the fixable part of #70.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>